### PR TITLE
Update site title to StreamLinks

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import './globals.css'
 
 export const metadata: Metadata = {
-  title: 'v0 App',
+  title: 'StreamLinks',
   description: 'Created with v0',
   generator: 'v0.dev',
 }


### PR DESCRIPTION
The tab title was previously displaying 'v0 App'. This change updates the title in app/layout.tsx to 'StreamLinks' to accurately reflect your site's name.