### PR TITLE
feat: Make "Most Popular" button scroll to section

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   font-family: Arial, Helvetica, sans-serif;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -42,9 +42,11 @@ export default function Home() {
           </p>
           <div className="flex flex-wrap justify-center gap-4">
             <Button className="bg-gray-100 hover:bg-white text-gray-900">Browse Categories</Button>
-            <Button variant="outline" className="border-gray-700 text-gray-300 hover:bg-gray-800 hover:text-white">
-              Most Popular
-            </Button>
+            <Link href="#popular-links">
+              <Button variant="outline" className="border-gray-700 text-gray-300 hover:bg-gray-800 hover:text-white">
+                Most Popular
+              </Button>
+            </Link>
           </div>
         </div>
       </section>
@@ -91,7 +93,7 @@ export default function Home() {
       </section>
 
       {/* Popular Links Section */}
-      <section className="py-16 bg-gray-900 border-t border-gray-800">
+      <section id="popular-links" className="py-16 bg-gray-900 border-t border-gray-800">
         <div className="container mx-auto px-4">
           <h2 className="text-3xl font-semibold text-white mb-8 text-center">Popular Streaming Sites</h2>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">


### PR DESCRIPTION
This change updates the "Most Popular" button on the main page so that clicking it smoothly scrolls you down to the "Popular Streaming Sites" section on the same page.

Changes made:
- Added an `id="popular-links"` to the target section in `app/page.tsx`.
- Wrapped the "Most Popular" `Button` component with a Next.js `Link` component, pointing its `href` to `"#popular-links"`.
- Ensured smooth scrolling behavior by adding `scroll-behavior: smooth;` to the `html` element in `app/globals.css`.